### PR TITLE
adds Category and reworks everything to work with it

### DIFF
--- a/src/main/java/FunctionLayer/BillCalculator.java
+++ b/src/main/java/FunctionLayer/BillCalculator.java
@@ -48,12 +48,12 @@ public class BillCalculator {
                 break;
         }
 
-        //Get the materials available within each category
-        ArrayList<Material> materialsAvailable = LogicFacade.getTheseMaterials(categoriesNeeded);
+        //Get each category
+        ArrayList<Category> categoriesAvailable = LogicFacade.getTheseCategories(categoriesNeeded);
 
         //Used to calculate bill lines
-        ArrayList<Material> materialsUsedInGenerator = null;
-        int[] categoriesUsedInGenerator = null;
+        ArrayList<Category> categoriesUsedInGenerator = null;
+        int[] categoryIdsUsedInGenerator = null;
         BillLine billLine = null;
 
         //Used to hold all BillLines
@@ -67,288 +67,288 @@ public class BillCalculator {
                 //TODO Translate to English
                 case 1: //understernbrædder til for & bag ende
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.underSternsBredderFrontAndBack(materialsUsedInGenerator,order.getWidth());
+                    billLine = CarportGenerator.underSternsBredderFrontAndBack(categoriesUsedInGenerator,order.getWidth());
                     break;
                 case 2: //understernbrædder til siderne
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.underSternsBredderSides(materialsUsedInGenerator);
+                    billLine = CarportGenerator.underSternsBredderSides(categoriesUsedInGenerator);
                     break;
                 case 3: //oversternbrædder til forenden
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.overSternBredderFront(materialsUsedInGenerator);
+                    billLine = CarportGenerator.overSternBredderFront(categoriesUsedInGenerator);
                     break;
                 case 4: //oversternbrædder til siderne
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.overSternBredderSides(materialsUsedInGenerator);
+                    billLine = CarportGenerator.overSternBredderSides(categoriesUsedInGenerator);
                     break;
                 case 5: //til z på bagside af dør
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = ShedGenerator.zOnBackOfDoor(materialsUsedInGenerator);
+                    billLine = ShedGenerator.zOnBackOfDoor(categoriesUsedInGenerator);
                     break;
                 case 6: //løsholter til skur gavle
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = ShedGenerator.losholterGabled(materialsUsedInGenerator);
+                    billLine = ShedGenerator.losholterGabled(categoriesUsedInGenerator);
                     break;
                 case 7: //løsholter til skur sider
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = ShedGenerator.losholterSides(materialsUsedInGenerator);
+                    billLine = ShedGenerator.losholterSides(categoriesUsedInGenerator);
                     break;
                 case 8: //Remme i sider, sadles ned i stolpe
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.RemInSidesCarport(materialsUsedInGenerator);
+                    billLine = CarportGenerator.RemInSidesCarport(categoriesUsedInGenerator);
                     break;
                 case 9: //Remme i sider, sadles ned i stolper (skur del, deles)
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = ShedGenerator.RemInSidesShed(materialsUsedInGenerator);
+                    billLine = ShedGenerator.RemInSidesShed(categoriesUsedInGenerator);
                     break;
                 case 10: //Spær, monteres på rem
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.sperOnRem(materialsUsedInGenerator);
+                    billLine = CarportGenerator.sperOnRem(categoriesUsedInGenerator);
                     break;
                 case 11: //Stolper nedgraves 90 cm. i jord
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.posts(materialsUsedInGenerator,order);
+                    billLine = CarportGenerator.posts(categoriesUsedInGenerator,order);
                     break;
                 case 12: //til beklædning af skur 1 på 2
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = ShedGenerator.boardsForShed(materialsUsedInGenerator);
+                    billLine = ShedGenerator.boardsForShed(categoriesUsedInGenerator);
                     break;
                 case 13: //vandbrædt på stern i sider
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = FlatRoofGenerator.waterBoardOnSternSides(materialsUsedInGenerator);
+                    billLine = FlatRoofGenerator.waterBoardOnSternSides(categoriesUsedInGenerator);
                     break;
                 case 14: //vandbrædt på stern i forende
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = FlatRoofGenerator.waterBoardOnSternFront(materialsUsedInGenerator);
+                    billLine = FlatRoofGenerator.waterBoardOnSternFront(categoriesUsedInGenerator);
                     break;
                 case 15: //tagplader monteres på spær
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = FlatRoofGenerator.roofPanels(materialsUsedInGenerator);
+                    billLine = FlatRoofGenerator.roofPanels(categoriesUsedInGenerator);
                     break;
                 case 16: //Skruer til tagplader
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = FlatRoofGenerator.screwsForRoofPanels(materialsUsedInGenerator);
+                    billLine = FlatRoofGenerator.screwsForRoofPanels(categoriesUsedInGenerator);
                     break;
                 case 17: //Til vindkryds på spær
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.perforatedBand(materialsUsedInGenerator);
+                    billLine = CarportGenerator.perforatedBand(categoriesUsedInGenerator);
                     break;
                 case 18: //Til montering af spær på rem - højre
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.UniversalBeslagRight(materialsUsedInGenerator);
+                    billLine = CarportGenerator.UniversalBeslagRight(categoriesUsedInGenerator);
                     break;
                 case 19: //Til montering af spær på rem - venstre
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.UniversalBeslagLeft(materialsUsedInGenerator);
+                    billLine = CarportGenerator.UniversalBeslagLeft(categoriesUsedInGenerator);
                     break;
                 case 20: //Til montering af stern & vandbrædt
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.screwsForSternAndWaterBoard(materialsUsedInGenerator);
+                    billLine = CarportGenerator.screwsForSternAndWaterBoard(categoriesUsedInGenerator);
                     break;
                 case 21: //Til montering af universalbeslag + hulbånd
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.screwsForUniversalBeslagAndPerforatedBand(materialsUsedInGenerator);
+                    billLine = CarportGenerator.screwsForUniversalBeslagAndPerforatedBand(categoriesUsedInGenerator);
                     break;
                 case 22: //Til montering af rem på stolper - bolte
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.boltsForRemOnPost(materialsUsedInGenerator);
+                    billLine = CarportGenerator.boltsForRemOnPost(categoriesUsedInGenerator);
                     break;
                 case 23: //Til montering af rem på stolper - skiver
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.skiverForRemOnPost(materialsUsedInGenerator);
+                    billLine = CarportGenerator.skiverForRemOnPost(categoriesUsedInGenerator);
                     break;
                 case 24: //til montering af yderste beklædning
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.screwsForOuter(materialsUsedInGenerator);
+                    billLine = CarportGenerator.screwsForOuter(categoriesUsedInGenerator);
                     break;
                 case 25: //til montering af inderste beklædning
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = CarportGenerator.screwsForInner(materialsUsedInGenerator);
+                    billLine = CarportGenerator.screwsForInner(categoriesUsedInGenerator);
                     break;
                 case 26: //Til lås på dør i skur
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = ShedGenerator.stalddorsgreb(materialsUsedInGenerator);
+                    billLine = ShedGenerator.stalddorsgreb(categoriesUsedInGenerator);
                     break;
                 case 27: //Til skurdør
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = ShedGenerator.hingeForDoor(materialsUsedInGenerator);
+                    billLine = ShedGenerator.hingeForDoor(categoriesUsedInGenerator);
                     break;
                 case 28: //Til montering af løsholter i skur
                     //The material categories needed in the generator method
-                    categoriesUsedInGenerator = new int[]{1,2};
+                    categoryIdsUsedInGenerator = new int[]{1,2};
 
                     //Gets a list with only the categories needed
-                    materialsUsedInGenerator = getMaterialsUsedInGenerator(categoriesUsedInGenerator, materialsAvailable);
+                    categoriesUsedInGenerator = getCategoriesUsedInGenerator(categoryIdsUsedInGenerator, categoriesAvailable);
 
                     //Calls the generator and returns the BillLine
-                    billLine = ShedGenerator.vinkelBeslag(materialsUsedInGenerator);
+                    billLine = ShedGenerator.vinkelBeslag(categoriesUsedInGenerator);
                     break;
             }
             if(billLine != null){
                 billLines.add(billLine);
-                materialsUsedInGenerator.clear();
+                categoriesUsedInGenerator.clear();
             }
 
         }
@@ -356,22 +356,22 @@ public class BillCalculator {
         return billLines;
     }
 
-    private ArrayList<Material> getMaterialsUsedInGenerator(int[] categoriesUsedInGenerator,ArrayList<Material> materialsAvailable) {
-        ArrayList<Material> materialsUsedInGenerator = new ArrayList<Material>();
+    private ArrayList<Category> getCategoriesUsedInGenerator(int[] categoryIdsUsedInGenerator, ArrayList<Category> categoriesAvailable) {
+        ArrayList<Category> categoriesUsedInGenerator = new ArrayList<>();
 
         //Loop all categories needed in Generator
-        for(int categoryID : categoriesUsedInGenerator){
+        for(int categoryID : categoryIdsUsedInGenerator){
 
             //Loop all materials available to search for the categoryID
-            for(Material material : materialsAvailable){
-                if(material != null && material.getCategory() == categoryID){
-                    materialsUsedInGenerator.add(material);
+            for(Category category : categoriesAvailable){
+                if(category != null && category.getCategoryId() == categoryID){
+                    categoriesUsedInGenerator.add(category);
 
                     //When the material has been found exit
                     break;
                 }
             }
         }
-        return materialsUsedInGenerator;
+        return categoriesUsedInGenerator;
     }
 }

--- a/src/main/java/FunctionLayer/BillGenerator/CarportGenerator.java
+++ b/src/main/java/FunctionLayer/BillGenerator/CarportGenerator.java
@@ -4,6 +4,7 @@ import Components.DepthComponent;
 import Components.HeightComponent;
 import Components.WidthComponent;
 import FunctionLayer.BillLine;
+import FunctionLayer.Category;
 import FunctionLayer.Material;
 import FunctionLayer.Order;
 
@@ -11,32 +12,32 @@ import java.util.ArrayList;
 
 public class CarportGenerator {
 
-    public static BillLine underSternsBredderFrontAndBack(ArrayList<Material> materialsUsedInGenerator, WidthComponent carpotWidth) {
+    public static BillLine underSternsBredderFrontAndBack(ArrayList<Category> categoriesUsedInGenerator, WidthComponent carpotWidth) {
         return null;
     }
 
-    public static BillLine underSternsBredderSides(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine underSternsBredderSides(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine overSternBredderFront(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine overSternBredderFront(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine overSternBredderSides(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine overSternBredderSides(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
     
 
-    public static BillLine RemInSidesCarport(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine RemInSidesCarport(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine sperOnRem(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine sperOnRem(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine posts(ArrayList<Material> materialsUsedInGenerator, Order order) {
+    public static BillLine posts(ArrayList<Category> categoriesUsedInGenerator, Order order) {
         int numberOfPostRows = 2;
         int numberOfPostPerRow = 2;
         int total = 0;
@@ -65,43 +66,43 @@ public class CarportGenerator {
 
         //TODO calculate best material fit
 
-        BillLine billLine = new BillLine(materialsUsedInGenerator.get(0),total);
+        BillLine billLine = new BillLine(categoriesUsedInGenerator.get(0),total);
         return billLine;
     }
 
-    public static BillLine perforatedBand(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine perforatedBand(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine UniversalBeslagRight(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine UniversalBeslagRight(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine screwsForSternAndWaterBoard(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine screwsForSternAndWaterBoard(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine screwsForUniversalBeslagAndPerforatedBand(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine screwsForUniversalBeslagAndPerforatedBand(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine boltsForRemOnPost(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine boltsForRemOnPost(ArrayList<Category> materialsUsedInGenerator) {
         return null;
     }
 
-    public static BillLine skiverForRemOnPost(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine skiverForRemOnPost(ArrayList<Category> materialsUsedInGenerator) {
         return null;
     }
 
-    public static BillLine screwsForOuter(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine screwsForOuter(ArrayList<Category> materialsUsedInGenerator) {
         return null;
     }
 
-    public static BillLine screwsForInner(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine screwsForInner(ArrayList<Category> materialsUsedInGenerator) {
         return null;
     }
 
-    public static BillLine UniversalBeslagLeft(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine UniversalBeslagLeft(ArrayList<Category> materialsUsedInGenerator) {
         return null;
     }
 }

--- a/src/main/java/FunctionLayer/BillGenerator/FlatRoofGenerator.java
+++ b/src/main/java/FunctionLayer/BillGenerator/FlatRoofGenerator.java
@@ -1,24 +1,25 @@
 package FunctionLayer.BillGenerator;
 
 import FunctionLayer.BillLine;
+import FunctionLayer.Category;
 import FunctionLayer.Material;
 
 import java.util.ArrayList;
 
 public class FlatRoofGenerator {
-    public static BillLine waterBoardOnSternSides(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine waterBoardOnSternSides(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine waterBoardOnSternFront(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine waterBoardOnSternFront(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine roofPanels(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine roofPanels(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine screwsForRoofPanels(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine screwsForRoofPanels(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 }

--- a/src/main/java/FunctionLayer/BillGenerator/ShedGenerator.java
+++ b/src/main/java/FunctionLayer/BillGenerator/ShedGenerator.java
@@ -1,40 +1,41 @@
 package FunctionLayer.BillGenerator;
 
 import FunctionLayer.BillLine;
+import FunctionLayer.Category;
 import FunctionLayer.Material;
 
 import java.util.ArrayList;
 
 public class ShedGenerator {
-    public static BillLine zOnBackOfDoor(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine zOnBackOfDoor(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine losholterGabled(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine losholterGabled(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine RemInSidesShed(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine RemInSidesShed(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine losholterSides(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine losholterSides(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine boardsForShed(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine boardsForShed(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine stalddorsgreb(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine stalddorsgreb(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine hingeForDoor(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine hingeForDoor(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 
-    public static BillLine vinkelBeslag(ArrayList<Material> materialsUsedInGenerator) {
+    public static BillLine vinkelBeslag(ArrayList<Category> categoriesUsedInGenerator) {
         return null;
     }
 }

--- a/src/main/java/FunctionLayer/BillLine.java
+++ b/src/main/java/FunctionLayer/BillLine.java
@@ -1,20 +1,20 @@
 package FunctionLayer;
 
 public class BillLine {
-    private Material material;
+    private Category category;
     private int amount;
 
-    public BillLine(Material material, int amount) {
-        this.material = material;
+    public BillLine(Category category, int amount) {
+        this.category = category;
         this.amount = amount;
     }
 
-    public Material getMaterial() {
-        return material;
+    public Category getCategory() {
+        return category;
     }
 
-    public void setMaterial(Material material) {
-        this.material = material;
+    public void setCategory(Category category) {
+        this.category = category;
     }
 
     public int getAmount() {

--- a/src/main/java/FunctionLayer/Category.java
+++ b/src/main/java/FunctionLayer/Category.java
@@ -1,0 +1,88 @@
+package FunctionLayer;
+
+import java.util.ArrayList;
+
+public class Category {
+    private int categoryId;
+    private ArrayList<Material> materials;
+    private String description;
+
+    public Category(int categoryId, Material material, String description) {
+        materials = new ArrayList<>();
+
+        this.categoryId = categoryId;
+        materials.add(material);
+        this.description = description;
+    }
+
+    //---------//
+    // Getters //
+    //---------//
+    public int getCategoryId() {
+        return categoryId;
+    }
+    public String getDescription() {
+        return description;
+    }
+    public ArrayList<Material> getMaterials() {
+        return materials;
+    }
+    public Material getMaterialByMaterialId(int materialId) {
+        for(Material mat : materials) {
+            if (mat.getMaterialID() == materialId) {
+                return mat;
+            }
+        }
+        return null;
+    }
+    public Material getMaterialAtIndex(int index) {
+        return materials.get(index);
+    }
+    public Material getLongestMaterial() {
+        Material longest = materials.get(0);
+        for(int i = 1; i < materials.size(); i++) {
+            if (materials.get(i).getLength().getLength() > longest.getLength().getLength()) {
+                longest = materials.get(i);
+            }
+        }
+        return longest;
+    }
+    public Material getWidestMaterial() {
+        Material widest = materials.get(0);
+        for(int i = 1; i < materials.size(); i++) {
+            if (materials.get(i).getWidth().getWidth() > widest.getWidth().getWidth()) {
+                widest = materials.get(i);
+            }
+        }
+        return widest;
+    }
+    public Material getHighestMaterial() {
+        Material highest = materials.get(0);
+        for(int i = 1; i < materials.size(); i++) {
+            if (materials.get(i).getHeight().getHeight() > highest.getHeight().getHeight()) {
+                highest = materials.get(i);
+            }
+        }
+        return highest;
+    }
+
+    //---------//
+    // Setters //
+    //---------//
+    public void setCategoryId(int categoryId) {
+        this.categoryId = categoryId;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    //--------//
+    // Adders //
+    //--------//
+    public void addMaterial(Material material) {
+            materials.add(material);
+    }
+
+
+}
+

--- a/src/main/java/FunctionLayer/LogicFacade.java
+++ b/src/main/java/FunctionLayer/LogicFacade.java
@@ -26,18 +26,15 @@ public class LogicFacade {
     }
 
     public static void createOrder( Order order) throws CommandException, SQLException {
-        OrderMapper orderMapper = new OrderMapper();
-        orderMapper.createOrder(order);
+        OrderMapper.createOrder(order);
     }
 
     public static Order getOrder(int orderID) throws Exception {
-        OrderMapper orderMapper = new OrderMapper();
-        return orderMapper.getOrder(orderID);
+        return OrderMapper.getOrder(orderID);
     }
 
-    public static ArrayList<Material> getTheseMaterials(int[] categoriesNeeded) throws CommandException, SQLException, ValidationFailedException, ClassNotFoundException {
-        MaterialsMapper materialsMapper = new MaterialsMapper();
-        return materialsMapper.getTheseMaterials(categoriesNeeded);
+    public static ArrayList<Category> getTheseCategories(int[] categoriesNeeded) throws CommandException, SQLException, ValidationFailedException, ClassNotFoundException {
+        return MaterialsMapper.getTheseCategories(categoriesNeeded);
     }
 
     public static ArrayList<BillLine> getBillLines(int orderID) throws Exception {

--- a/src/main/java/FunctionLayer/Material.java
+++ b/src/main/java/FunctionLayer/Material.java
@@ -4,34 +4,28 @@ import Components.MaterialLengthComponent;
 import Components.MaterialHeightComponent;
 import Components.MaterialWidthComponent;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-
 
 public class Material {
     private int materialID;
     private MaterialHeightComponent height;
-    private String description;
+    private MaterialWidthComponent width;
+    private MaterialLengthComponent length;
+    private String name;
     private int costPrice;
     private int category;
-    private String helpText;
 
     //Used by BillCalculator
-    private HashMap<Integer, MaterialLengthComponent> materialLengths;
-    private HashMap<Integer, MaterialWidthComponent> materialWidths;
+    //private HashMap<Integer, MaterialLengthComponent> materialLengths;
+    //private HashMap<Integer, MaterialWidthComponent> materialWidths;
 
-    public Material(int materialID, MaterialLengthComponent length, MaterialHeightComponent height, MaterialWidthComponent width, String description, int costPrice, int category, String helpText) {
-        materialLengths = new HashMap<>();
-        materialWidths = new HashMap<>();
-        addMaterialLength(materialID, length);
-        addMaterialWidth(materialID, width);
-
+    public Material(int materialID, MaterialLengthComponent length, MaterialHeightComponent height, MaterialWidthComponent width, String name, int costPrice, int category) {
         this.materialID = materialID;
         this.height = height;
-        this.description = description;
+        this.width = width;
+        this.length = length;
+        this.name = name;
         this.costPrice = costPrice;
         this.category = category;
-        this.helpText = helpText;
     }
 
     //---------//
@@ -40,53 +34,23 @@ public class Material {
     public int getMaterialID() {
         return materialID;
     }
-
     public MaterialHeightComponent getHeight() {
         return height;
     }
-
-    public String getDescription() {
-        return description;
+    public MaterialWidthComponent getWidth() {
+        return width;
     }
-
+    public MaterialLengthComponent getLength() {
+        return length;
+    }
+    public String getName() {
+        return name;
+    }
     public int getCostPrice() {
         return costPrice;
     }
-
     public int getCategory() {
         return category;
-    }
-
-    public String getHelpText() {
-        return helpText;
-    }
-
-    public HashMap<Integer, MaterialLengthComponent> getMaterialLengths() {
-        return materialLengths;
-    }
-
-    public HashMap<Integer, MaterialWidthComponent> getMaterialWidths() {
-        return materialWidths;
-    }
-
-    //---------//
-    // Setters //
-    //---------//
-    public void setMaterialLengths(HashMap<Integer, MaterialLengthComponent> materialsLengths) {
-        this.materialLengths = materialsLengths;
-    }
-    public void setMaterialWidths(HashMap<Integer, MaterialWidthComponent> materialsWidth) {
-        this.materialWidths = materialsWidth;
-    }
-
-    //--------//
-    // Adders //
-    //--------//
-    public void addMaterialWidth(int materialID, MaterialWidthComponent widthToAdd) {
-        materialWidths.put(materialID, widthToAdd);
-    }
-    public void addMaterialLength(int materialID, MaterialLengthComponent lengthToAdd) {
-        materialLengths.put(materialID, lengthToAdd);
     }
 }
 

--- a/src/main/java/PresentationLayer/Bill.java
+++ b/src/main/java/PresentationLayer/Bill.java
@@ -1,7 +1,6 @@
 package PresentationLayer;
 
 import FunctionLayer.BillLine;
-import FunctionLayer.Exceptions.CommandException;
 import FunctionLayer.LogicFacade;
 
 import javax.servlet.http.HttpServletRequest;
@@ -18,7 +17,7 @@ public class Bill extends Command{
         try {
             billLines = LogicFacade.getBillLines(1);
             for(BillLine line: billLines){
-                System.out.println(line.getMaterial().getDescription() + " Antal: " + line.getAmount());
+                System.out.println(line.getCategory().getMaterialAtIndex(0).getName() + " Antal: " + line.getAmount());
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/test/java/DBAccess/MaterialMapperTest.java
+++ b/src/test/java/DBAccess/MaterialMapperTest.java
@@ -1,8 +1,7 @@
 package DBAccess;
 
 
-import Components.MaterialLengthComponent;
-import Components.MaterialWidthComponent;
+import FunctionLayer.Category;
 import FunctionLayer.Exceptions.ValidationFailedException;
 import FunctionLayer.Material;
 import org.junit.Test;
@@ -19,16 +18,16 @@ public class MaterialMapperTest {
     public void testGetAllMaterialsByContent() throws SQLException, ValidationFailedException, ClassNotFoundException {
         int indexToCheck = 5;
         String expected = "38x73 mm. Lægte ubh.";
-        ArrayList<Material> test = MaterialsMapper.getAllMaterials();
+        ArrayList<Category> test = MaterialsMapper.getAllCategories();
 
-        assertEquals(expected, test.get(5).getDescription());
+        assertEquals(expected, test.get(5).getMaterialAtIndex(0).getName());
     }
 
     @Test
     public void testGetTheseMaterialsBySize() throws SQLException, ValidationFailedException, ClassNotFoundException {
         int[] ids = new int[] {14,1,17,3,24,5,15,13,8,28};
 
-        ArrayList<Material> test = MaterialsMapper.getTheseMaterials(ids);
+        ArrayList<Category> test = MaterialsMapper.getTheseCategories(ids);
         //For visualisation purposes
        /* for (Material mat : test) {
             System.out.println(mat.getDescription());
@@ -44,7 +43,7 @@ public class MaterialMapperTest {
 
         int[] ids = new int[] {3,8,15,6};
 
-        ArrayList<Material> test = MaterialsMapper.getTheseMaterials(ids);
+        ArrayList<Category> test = MaterialsMapper.getTheseCategories(ids);
 
         //For visualisation purposes
         /*for (Material mat : test) {
@@ -58,10 +57,10 @@ public class MaterialMapperTest {
             System.out.println("");
         }*/
 
-        assertEquals(expectedLength1, test.get(3).getMaterialLengths().get(8).getLength());
-        assertEquals(expectedLength2, test.get(3).getMaterialLengths().get(22).getLength());
-        assertEquals(expectedWidth, test.get(3).getMaterialWidths().get(8).getWidth());
-        assertEquals(expectedWidth, test.get(3).getMaterialWidths().get(22).getWidth());
+        assertEquals(expectedLength1, test.get(3).getMaterialByMaterialId(8).getLength().getLength());
+        assertEquals(expectedLength2, test.get(3).getMaterialByMaterialId(22).getLength().getLength());
+        assertEquals(expectedWidth, test.get(3).getMaterialByMaterialId(8).getWidth().getWidth());
+        assertEquals(expectedWidth, test.get(3).getMaterialByMaterialId(22).getWidth().getWidth());
     }
 
     


### PR DESCRIPTION
Instead of having one material for each category, and then multiple lengths and heights for each material, thereby losing what could be unique information about the differing materials, we have reworked it so that each category (db) gets 1 (one) Category object, containing as many Material objects as there are materials (db) connected to that category (db) by the material_to_category translation table.

This gives us a better and more understandable translation between the database world and the java one, as well as more freedom to vary not just the length and width of materials contained in the same category, but all the different attributes.

This is a massive change, and while I have tested that it runs and the unit-tests have been rewritten, I am not 100% sure everything works, especially not the BillCalculator class, as I do not understandable what it is doing. Please look through it, and run it as well before merging the pull request.